### PR TITLE
Include "error" in status

### DIFF
--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -12,7 +12,7 @@ STATUS = {
     2: "PAUSED",
     3: "CHARGING",
     4: "READY_TO_CHARGE",
-    5: "UNKNOWN",
+    5: "ERROR",
     6: "CAR_CONNECTED",
 }
 


### PR DESCRIPTION
Offical status from Easee. Seems we have good names, although not exact match, but Easee also have differences between app/web etc. The unknown status is confirmed as ERROR.

```
OpModeType { 
	/// <summary> /// No car connected. /// </summary> Disconnected = 1, 
	/// <summary> /// Car connected, charger is waiting for load balancer or remote authorization. SuspendedEVSE. /// </summary> AwaitingStart = 2, 
	/// <summary> /// Charging. /// </summary> Charging = 3, 
	/// <summary> /// Car has paused/stopped charging. /// </summary> Completed = 4, 
	/// <summary> /// Error in charger. /// </summary> Error = 5, 
	/// <summary> /// Charger is waiting for car to take energy. SuspendedEV. /// </summary> ReadyToCharge = 6
}

```