### PR TITLE
Update status codes and

### DIFF
--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -7,13 +7,15 @@ from .utils import BaseDict
 
 _LOGGER = logging.getLogger(__name__)
 
+
 STATUS = {
-    1: "STANDBY",
-    2: "PAUSED",
+    0: "OFFLINE",
+    1: "DISCONNECTED",
+    2: "AWAITING_START",
     3: "CHARGING",
-    4: "READY_TO_CHARGE",
-    5: "UNKNOWN",
-    6: "CAR_CONNECTED",
+    4: "COMPLETED",
+    5: "ERROR",
+    6: "READY_TO_CHARGE",
 }
 
 NODE_TYPE = {1: "Master", 2: "Extender"}
@@ -24,10 +26,19 @@ REASON_FOR_NO_CURRENT = {
     # Work-in-progress, must be taken with a pinch of salt, as per now just reverse engineering of observations until API properly documented
     None: "No reason",
     0: "No reason, charging or ready to charge",
+    1: "Charger paused",
+    2: "Charger paused",
+    3: "Charger paused",
+    4: "Charger paused",
+    5: "Charger paused",
+    6: "Charger paused",
+    9: "Error no current",
     50: "Secondary unit not requesting current or no car connected",
+    51: "Charger paused",
     52: "Charger paused",
     53: "Charger disabled",
-    54: "Waiting for schedule",
+    54: "Waiting for schedule/auth",
+    55: "Pending auth"
 }
 
 
@@ -37,7 +48,7 @@ class ChargerState(BaseDict):
     def __init__(self, state: Dict[str, Any]):
         data = {
             **state,
-            "chargerOpMode": STATUS[state["chargerOpMode"]],
+            "status": STATUS[state["chargerOpMode"]],
             "reasonForNoCurrent": f"({state['reasonForNoCurrent']}) {REASON_FOR_NO_CURRENT.get(state['reasonForNoCurrent'], 'Unknown')}",
         }
         super().__init__(data)

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -2,13 +2,16 @@
 Main client for the Eesee account.
 """
 import asyncio
-import aiohttp
 import logging
 from datetime import datetime, timedelta
 from typing import Any, List
+
+import aiohttp
+
 from .charger import Charger
+from .exceptions import (AuthorizationFailedException, NotFoundException,
+                         ServerFailureException, TooManyRequestsException)
 from .site import Site, SiteState
-from .exceptions import AuthorizationFailedException, NotFoundException, TooManyRequestsException, ServerFailureException
 
 __VERSION__ = "0.7.25"
 

--- a/tests/test_charger.py
+++ b/tests/test_charger.py
@@ -104,7 +104,8 @@ async def test_get_correct_status():
     mock_easee = MockEasee(get_data=default_state)
     charger = Charger({"id": "EH123456", "name": "Easee Home 12345"}, mock_easee)
     state = await charger.get_state()
-    assert state["chargerOpMode"] == "CHARGING"
+    assert state["chargerOpMode"] == 3
+    assert state["status"] == "CHARGING"
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -95,10 +95,11 @@ async def test_get_site_state(aiosession, aioresponse):
     assert charger_config["localNodeType"] == "Master"
 
     charger_state = site_state.get_charger_state("EH123497")
-    assert charger_state["chargerOpMode"] == "STANDBY"
+    assert charger_state["chargerOpMode"] == 1
+    assert charger_state["status"] == "DISCONNECTED"
 
     charger_state = site_state.get_charger_state("NOTEXIST")
-    assert charger_state == None
+    assert charger_state is None
 
     await easee.close()
     await aiosession.close()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,11 @@
-import os
-import json
-import pytest
 import asyncio
-import aiohttp
-from aioresponses import aioresponses
+import json
+import os
 
-from pyeasee import Easee, Charger
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+from pyeasee import Charger, Easee
 
 BASE_URL = "https://api.easee.cloud"
 
@@ -43,7 +43,8 @@ async def test_get_chargers(aiosession, aioresponse):
     aioresponse.get(f"{BASE_URL}/api/chargers/EH12345/state", payload=chargers_state_data)
 
     state = await chargers[0].get_state()
-    assert state["chargerOpMode"] == "PAUSED"
+    assert state["chargerOpMode"] == 2
+    assert state["status"] == "AWAITING_START"
     await easee.close()
     await aiosession.close()
 


### PR DESCRIPTION
add status with the status string, raw access to chargerOpmode is now possible.

This will be a breaking change but i think the status codes are better, especially with the updated reason for no current as you get more info about that is happening. 

I also wanted to not overwrite the chargerOpmode so this is still a int and status is the string.

