### PR TITLE
Add raw mode, backwards compatible

### DIFF
--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -34,24 +34,30 @@ REASON_FOR_NO_CURRENT = {
 class ChargerState(BaseDict):
     """ Charger state with integer enum values converted to human readable string values"""
 
-    def __init__(self, state: Dict[str, Any]):
-        data = {
-            **state,
-            "chargerOpMode": STATUS[state["chargerOpMode"]],
-            "reasonForNoCurrent": f"({state['reasonForNoCurrent']}) {REASON_FOR_NO_CURRENT.get(state['reasonForNoCurrent'], 'Unknown')}",
-        }
+    def __init__(self, state: Dict[str, Any], raw=False):
+        if not raw:
+            data = {
+                **state,
+                "chargerOpMode": STATUS[state["chargerOpMode"]],
+                "reasonForNoCurrent": f"({state['reasonForNoCurrent']}) {REASON_FOR_NO_CURRENT.get(state['reasonForNoCurrent'], 'Unknown')}",
+            }
+        else:
+            data = {**state, "reasonForNoCurrent": "none" if state['reasonForNoCurrent'] is None else state['reasonForNoCurrent']}
         super().__init__(data)
 
 
 class ChargerConfig(BaseDict):
     """ Charger config with integer enum values converted to human readable string values"""
 
-    def __init__(self, config: Dict[str, Any]):
-        data = {
-            **config,
-            "localNodeType": NODE_TYPE[config["localNodeType"]],
-            "phaseMode": PHASE_MODE[config["phaseMode"]],
-        }
+    def __init__(self, config: Dict[str, Any], raw=False):
+        if not raw:
+            data = {
+                **config,
+                "localNodeType": NODE_TYPE[config["localNodeType"]],
+                "phaseMode": PHASE_MODE[config["phaseMode"]],
+            }
+        else:
+            data = {**config}
         super().__init__(data)
 
 
@@ -84,15 +90,15 @@ class Charger(BaseDict):
         ).text()
         return float(value)
 
-    async def get_config(self, from_cache=False) -> ChargerConfig:
+    async def get_config(self, from_cache=False, raw=False) -> ChargerConfig:
         """ get config for charger """
         config = await (await self.easee.get(f"/api/chargers/{self.id}/config")).json()
-        return ChargerConfig(config)
+        return ChargerConfig(config, raw)
 
-    async def get_state(self) -> ChargerState:
+    async def get_state(self, raw=False) -> ChargerState:
         """ get state for charger """
         state = await (await self.easee.get(f"/api/chargers/{self.id}/state")).json()
-        return ChargerState(state)
+        return ChargerState(state, raw)
 
     async def start(self):
         """Start charging session"""

--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -8,12 +8,12 @@ from .utils import BaseDict
 _LOGGER = logging.getLogger(__name__)
 
 STATUS = {
-    1: "STANDBY",
-    2: "PAUSED",
+    1: "DISCONNECTED",
+    2: "AWAITING_START",
     3: "CHARGING",
-    4: "READY_TO_CHARGE",
-    5: "UNKNOWN",
-    6: "CAR_CONNECTED",
+    4: "COMPLETED",
+    5: "ERROR",
+    6: "READY_TO_CHARGE",
 }
 
 NODE_TYPE = {1: "Master", 2: "Extender"}
@@ -24,10 +24,19 @@ REASON_FOR_NO_CURRENT = {
     # Work-in-progress, must be taken with a pinch of salt, as per now just reverse engineering of observations until API properly documented
     None: "No reason",
     0: "No reason, charging or ready to charge",
+    1: "Charger paused",
+    2: "Charger paused",
+    3: "Charger paused",
+    4: "Charger paused",
+    5: "Charger paused",
+    6: "Charger paused",
+    9: "Error no current",
     50: "Secondary unit not requesting current or no car connected",
+    51: "Charger paused",
     52: "Charger paused",
     53: "Charger disabled",
     54: "Waiting for schedule",
+    55: "Pending auth",
 }
 
 

--- a/pyeasee/site.py
+++ b/pyeasee/site.py
@@ -61,21 +61,21 @@ class SiteState(BaseDict):
     def __init__(self, data: Dict[str, Any]):
         super().__init__(data)
 
-    def get_charger_config(self, charger_id: str) -> ChargerConfig:
+    def get_charger_config(self, charger_id: str, raw=False) -> ChargerConfig:
         """ get config for charger from the instance data"""
         for circuit in self["circuitStates"]:
             for charger_data in circuit["chargerStates"]:
                 if charger_data["chargerID"] == charger_id:
-                    return ChargerConfig(charger_data["chargerConfig"])
+                    return ChargerConfig(charger_data["chargerConfig"], raw)
 
         return None
 
-    def get_charger_state(self, charger_id: str) -> ChargerState:
+    def get_charger_state(self, charger_id: str, raw=False) -> ChargerState:
         """ get state for charger from the instance data"""
         for circuit in self["circuitStates"]:
             for charger_data in circuit["chargerStates"]:
                 if charger_data["chargerID"] == charger_id:
-                    return ChargerState(charger_data["chargerState"])
+                    return ChargerState(charger_data["chargerState"], raw)
 
         return None
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,7 +43,7 @@ async def test_get_chargers(aiosession, aioresponse):
     aioresponse.get(f"{BASE_URL}/api/chargers/EH12345/state", payload=chargers_state_data)
 
     state = await chargers[0].get_state()
-    assert state["chargerOpMode"] == "PAUSED"
+    assert state["chargerOpMode"] == "AWAITING_START"
     await easee.close()
     await aiosession.close()
 
@@ -94,7 +94,7 @@ async def test_get_site_state(aiosession, aioresponse):
     assert charger_config["localNodeType"] == "Master"
 
     charger_state = site_state.get_charger_state("EH123497")
-    assert charger_state["chargerOpMode"] == "STANDBY"
+    assert charger_state["chargerOpMode"] == "DISCONNECTED"
 
     charger_state = site_state.get_charger_state("NOTEXIST")
     assert charger_state == None


### PR DESCRIPTION
Added raw mode that presents raw data from the api. Except for the little change that None in Reason_for_no_current is changed to string "none".
The intention is that this PR is fully backwards compatible. CLI tools and current release of easee are not affected.
Text mappings in pyeasee are not changed. 
My idea is to map integer values to translatable strings in easee.
I think this PR can be merged and released to pypi after review. It will simplify further development in easee if the library is available as a new release.