### PR TITLE
Fix smart_charging()

### DIFF
--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -189,10 +189,11 @@ class Charger(BaseDict):
         """Override scheduled charging and start charging"""
         return await self.easee.post(f"/api/chargers/{self.id}/commands/override_schedule")
 
-    async def smart_charging(self):
+    async def smart_charging(self, enable: bool):
         """Set charger smart charging setting"""
-        return await self.easee.post(f"/api/chargers/{self.id}/commands/smart_charging")
-
+        json = {"smartCharging": enable}
+        return await self.easee.post(f"/api/chargers/{self.id}/settings", json=json)
+        
     async def reboot(self):
         """Reboot charger"""
         return await self.easee.post(f"/api/chargers/{self.id}/commands/reboot")


### PR DESCRIPTION
Fix smart_charging() method and add bool to turn on or off. Original API call to /api/chargers/{id}/commands/smart_charging was believed to be a toggle, but updated docs says it is only to turn on and that settings must be used to turn off: «Turn off smart charging again by posting an explicit value to the charger settings endpoint».

So to summarize, why not use call to /api/chargers/{id}/settings to turn both on and off. Tested to be working with HA switch as well.