### PR TITLE
Pin version 0.8.8 of signalrcore lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     ],
     packages=["pyeasee"],
     include_package_data=True,
-    install_requires=["aiohttp", "signalrcore>=0.8.8"],
+    install_requires=["aiohttp", "signalrcore==0.8.8"],
     entry_points={"console_scripts": ["pyeasee=pyeasee.__main__:main"]},
 )


### PR DESCRIPTION
signalrcore 0.8.9 has breaking changes, so pinning 0.8.8 lib version for now.