### PR TITLE
Pin websocket version

### DIFF
--- a/pyeasee/const.py
+++ b/pyeasee/const.py
@@ -41,9 +41,9 @@ class ChargerStreamData(Enum):
     state_ledMode = 46
     config_maxChargerCurrent = 47
     state_dynamicChargerCurrent = 48
-    config_maxCurrentOfflineFallbackP1 = 50
-    config_maxCurrentOfflineFallbackP2 = 51
-    config_maxCurrentOfflineFallbackP3 = 52
+    state_offlineMaxCircuitCurrentP1 = 50
+    state_offlineMaxCircuitCurrentP2 = 51
+    state_offlineMaxCircuitCurrentP3 = 52
     schedule_chargingSchedule = 62
     config_pairedEqualizer = 65
     state_wiFiAPEnabled = 68

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -51,6 +51,6 @@ typed-ast==1.4.1
 urllib3==1.25.9
 wcwidth==0.2.5
 webencodings==0.5.1
-websocket-client==0.57.0
+websocket-client==0.54.0
 yarl==1.4.2
 zipp==3.1.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     ],
     packages=["pyeasee"],
     include_package_data=True,
-    install_requires=["aiohttp", "signalrcore==0.8.8"],
+    install_requires=["aiohttp", "signalrcore==0.8.8", "websocket-client==0.57.0"],
     entry_points={"console_scripts": ["pyeasee=pyeasee.__main__:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     ],
     packages=["pyeasee"],
     include_package_data=True,
-    install_requires=["aiohttp", "signalrcore==0.8.8", "websocket-client==0.57.0"],
+    install_requires=["aiohttp", "signalrcore==0.8.8", "websocket-client==0.54.0"],
     entry_points={"console_scripts": ["pyeasee=pyeasee.__main__:main"]},
 )


### PR DESCRIPTION
Adding requirement to use 0.57.0 version of websocket because of incompatibility with signalrcore lib in later version.
Correcting names for offline mode current limits.