### PR TITLE
Improved authentication and retry for signalr connection

### DIFF
--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -212,10 +212,8 @@ class Easee:
         await self._sr_disconnect()
 
     def _sr_next(self):
-        if self._sr_backoff >= SR_MAX_BACKOFF:
-            return self._sr_backoff
-
-        self._sr_backoff = self._sr_backoff + SR_INC_BACKOFF
+        if self._sr_backoff < SR_MAX_BACKOFF:
+            self._sr_backoff = self._sr_backoff + SR_INC_BACKOFF
         return self._sr_backoff
 
     def _sr_token(self):

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -228,7 +228,7 @@ class Easee:
         if "accessToken" not in self.token:
             accessToken = ""
         else:
-            accessToken = self.token["accessToken"] + "FAIL"
+            accessToken = self.token["accessToken"]
         return accessToken
 
     def _sr_open_cb(self):

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -240,7 +240,7 @@ class Easee:
 
         for id in self.sr_subscriptions:
             _LOGGER.debug("Subscribing to %s", id)
-            self.sr_connection.send("SubscribeWithCurrentState", [id, True])
+            asyncio.ensure_future(self.sr_connection.send("SubscribeWithCurrentState", [id, True]))
         self.sr_connected = True
 
     def _sr_close_cb(self):
@@ -356,7 +356,7 @@ class Easee:
         _LOGGER.debug("Subscribing to %s", product.id)
         self.sr_subscriptions[product.id] = callback
         if self.sr_connected is True:
-            self.sr_connection.send("SubscribeWithCurrentState", [product.id, True])
+            asyncio.ensure_future(self.sr_connection.send("SubscribeWithCurrentState", [product.id, True]))
         else:
             await self._sr_connect()
 


### PR DESCRIPTION
Stop relying on signalcore lib internal retries when disconnected from server and instead restart the connection process.
Catch authentication errors when connecting to signalr server and try to refresh token if it fails.
Bug in _refresh_token function fixed.
User-Agent added.
.send() now called from a thread due to potentially blocking.