### PR TITLE
Charger.set_dynamic_charger_circuit_current extended 

### DIFF
--- a/html/pyeasee/charger.html
+++ b/html/pyeasee/charger.html
@@ -164,16 +164,16 @@
 <div class="desc"><p>Set and post charger basic charge plan setting to cloud</p></div>
 </dd>
 <dt id="pyeasee.charger.Charger.set_dynamic_charger_circuit_current"><code class="name flex">
-<span>async def <span class="ident">set_dynamic_charger_circuit_current</span></span>(<span>self, currentP1: int, currentP2: int = None, currentP3: int = None)</span>
+<span>async def <span class="ident">set_dynamic_charger_circuit_current</span></span>(<span>self, currentP1: int, currentP2: int = None, currentP3: int = None, timeToLive: int = None)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Set circuit dynamic current for charger</p></div>
+<div class="desc"><p>Set dynamic current on circuit level. timeToLive specifies, in minutes, for how long the setting is valid. If set to 0, it is valid until changed the next time. If omitted, it is valid until the start of a new charging session. The dynamic current is always reset to default when the charger is power cycled</p></div>
 </dd>
 <dt id="pyeasee.charger.Charger.set_dynamic_charger_current"><code class="name flex">
 <span>async def <span class="ident">set_dynamic_charger_current</span></span>(<span>self, current: int)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Set charger dynamic current</p></div>
+<div class="desc"><p>Set charger dynamic current. The dynamic current is always reset to default when the charger is power cycled and at the start of each charging session</p></div>
 </dd>
 <dt id="pyeasee.charger.Charger.set_max_charger_circuit_current"><code class="name flex">
 <span>async def <span class="ident">set_max_charger_circuit_current</span></span>(<span>self, currentP1: int, currentP2: int = None, currentP3: int = None)</span>

--- a/html/pyeasee/charger.html
+++ b/html/pyeasee/charger.html
@@ -167,7 +167,7 @@
 <span>async def <span class="ident">set_dynamic_charger_circuit_current</span></span>(<span>self, currentP1: int, currentP2: int = None, currentP3: int = None, timeToLive: int = None)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Set dynamic current on circuit level. timeToLive specifies, in minutes, for how long the setting is valid. If set to 0, it is valid until changed the next time. If omitted, it is valid until the start of a new charging session. The dynamic current is always reset to default when the charger is power cycled</p></div>
+<div class="desc"><p>Set dynamic current on circuit level. timeToLive specifies, in minutes, for how long the new dynamic current is valid. If timeToLive is set to 0 or omitted, the new dynamic current is valid until changed the next time. The dynamic current is always reset to default when the charger is restarted</p></div>
 </dd>
 <dt id="pyeasee.charger.Charger.set_dynamic_charger_current"><code class="name flex">
 <span>async def <span class="ident">set_dynamic_charger_current</span></span>(<span>self, current: int)</span>

--- a/html/pyeasee/site.html
+++ b/html/pyeasee/site.html
@@ -56,10 +56,10 @@
 <div class="desc"></div>
 </dd>
 <dt id="pyeasee.site.Circuit.set_dynamic_current"><code class="name flex">
-<span>async def <span class="ident">set_dynamic_current</span></span>(<span>self, currentP1: int, currentP2: int = None, currentP3: int = None)</span>
+<span>async def <span class="ident">set_dynamic_current</span></span>(<span>self, currentP1: int, currentP2: int = None, currentP3: int = None, timeToLive: int = None)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Set circuit dynamic current</p></div>
+<div class="desc"><p>Set dynamic current on circuit level. timeToLive specifies, in minutes, for how long the new dynamic current is valid. If timeToLive is set to 0 or omitted, the new dynamic current is valid until changed the next time. The dynamic current is always reset to default when the charger is restarted</p></div>
 </dd>
 <dt id="pyeasee.site.Circuit.set_max_current"><code class="name flex">
 <span>async def <span class="ident">set_max_current</span></span>(<span>self, currentP1: int, currentP2: int = None, currentP3: int = None)</span>

--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -398,8 +398,8 @@ class Charger(BaseDict):
         except (ServerFailureException):
             return None
 
-    async def set_dynamic_charger_circuit_current(self, currentP1: int, currentP2: int = None, currentP3: int = None, timeToLive: int = None):
-        """ Set circuit dynamic current for charger """
+    async def set_dynamic_charger_circuit_current(self, currentP1: int, currentP2: int = None, currentP3: int = None, timeToLive: int = 0):
+        """ Set dynamic current on circuit level. timeToLive specifies, in minutes, for how long the new dynamic current is valid. timeToLive = 0 means that the new dynamic current is valid until changed the next time. The dynamic current is always reset to default when the charger is restarted."""
         if self.circuit is not None:
             return await self.circuit.set_dynamic_current(currentP1, currentP2, currentP3, timeToLive)
         else:

--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -398,10 +398,10 @@ class Charger(BaseDict):
         except (ServerFailureException):
             return None
 
-    async def set_dynamic_charger_circuit_current(self, currentP1: int, currentP2: int = None, currentP3: int = None):
+    async def set_dynamic_charger_circuit_current(self, currentP1: int, currentP2: int = None, currentP3: int = None, timeToLive: int = None):
         """ Set circuit dynamic current for charger """
         if self.circuit is not None:
-            return await self.circuit.set_dynamic_current(currentP1, currentP2, currentP3)
+            return await self.circuit.set_dynamic_current(currentP1, currentP2, currentP3, timeToLive)
         else:
             _LOGGER.info("Circuit info must be initialized for dynamic current to be set")
 

--- a/pyeasee/site.py
+++ b/pyeasee/site.py
@@ -55,8 +55,8 @@ class Circuit(BaseDict):
         self.easee = easee
 
  
-    async def set_dynamic_current(self, currentP1: int, currentP2: int = None, currentP3: int = None, timeToLive: int = None):
-        """ Set circuit dynamic current """
+    async def set_dynamic_current(self, currentP1: int, currentP2: int = None, currentP3: int = None, timeToLive: int = 0):
+        """ Set dynamic current on circuit level. timeToLive specifies, in minutes, for how long the new dynamic current is valid. timeToLive = 0 means that the new dynamic current is valid until changed the next time. The dynamic current is always reset to default when the charger is restarted"""
         json = {
             "phase1": currentP1,
             "phase2": currentP2 if currentP2 is not None else currentP1,

--- a/pyeasee/site.py
+++ b/pyeasee/site.py
@@ -57,34 +57,16 @@ class Circuit(BaseDict):
  
     async def set_dynamic_current(self, currentP1: int, currentP2: int = None, currentP3: int = None, timeToLive: int = None):
         """ Set circuit dynamic current """
-        """ Compatibility note:
-            If timeToLive is supplied, then use another API call which accepts this argument.
-            timeToLive is expressed in minutes, where 0 means that the dynamic current setting is valid until it is changed with a new command or power cycle
-        """
-        if timeToLive is None:
-            print("set_dynamic_current: legacy call")
-            json = {
-                "dynamicCircuitCurrentP1": currentP1,
-                "dynamicCircuitCurrentP2": currentP2 if currentP2 is not None else currentP1,
-                "dynamicCircuitCurrentP3": currentP3 if currentP3 is not None else currentP1,
-            }
-            try:
-
-                return await self.easee.post(f"/api/sites/{self.site.id}/circuits/{self.id}/settings", json=json)
-            except (ServerFailureException):
-                return None
-        else:
-            print("set_dynamic_current: new call")
-            json = {
-                "phase1": currentP1,
-                "phase2": currentP2 if currentP2 is not None else currentP1,
-                "phase3": currentP3 if currentP3 is not None else currentP1,
-                "timeToLive": timeToLive,
-            }
-            try:
-                return await self.easee.post(f"/api/sites/{self.site.id}/circuits/{self.id}/dynamicCurrent", json=json)
-            except (ServerFailureException):
-                return None
+        json = {
+            "phase1": currentP1,
+            "phase2": currentP2 if currentP2 is not None else currentP1,
+            "phase3": currentP3 if currentP3 is not None else currentP1,
+            "timeToLive": timeToLive,
+        }
+        try:
+            return await self.easee.post(f"/api/sites/{self.site.id}/circuits/{self.id}/dynamicCurrent", json=json)
+        except (ServerFailureException):
+            return None
 
     async def set_max_current(self, currentP1: int, currentP2: int = None, currentP3: int = None):
         """ Set circuit max current """


### PR DESCRIPTION
Updated code for how to set dynamic current limit on circuit level. Affects two methods:
**Charger.set_dynamic_charger_circuit_current**
New optional parameter, timeToLive has been added.

**Circuit.set_dynamic_current**
New optional parameter, timeToLive has been added.

timeToLive specifies, in minutes, the validity of the new current limit.
If timeToLive is set to zero, then the setting is valid until the next time it is changed, or the charger is restarted. This call is used: https://api.easee.cloud/api/sites/siteId/circuits/circuitId/dynamicCurrent
If timeToLive is omitted, then the old code will be executed. This means that the new current limit will be valid until the next time it is changed, a new charging sessions starts, or the charger is restarted, whichever comes first.

API documentation has been updated accordingly