### PR TITLE
Changed datetime parsing

### DIFF
--- a/pyeasee/utils.py
+++ b/pyeasee/utils.py
@@ -58,7 +58,8 @@ class BaseDict(Mapping):
                 try:
                     return datetime.strptime(self._storage[key], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
                 except ValueError:
-                    return datetime.strptime(self._storage[key], "%Y-%m-%dT%H:%M:%S.000Z").replace(tzinfo=timezone.utc)
+                    (dt, msecs) = self._storage[key].split(".")
+                    return datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc)
         return self._storage[key]
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
The format returned from the Easee API may have a varying number of fractional second digits, this change aims to solve that by ignoring the fractions completely.