### PR TITLE
Move header update after token refresh

### DIFF
--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -86,6 +86,7 @@ class Easee:
             "Accept": "application/json",
             "Content-Type": "application/json;charset=UTF-8",
         }
+        self.minimal_headers = self.headers
         self.sr_headers = {
             "User-Agent": f"pyeasee/{__VERSION__} SignalR client",
             "Accept": "application/json",
@@ -181,7 +182,7 @@ class Easee:
         """
         data = {"userName": self.username, "password": self.password}
         _LOGGER.debug("getting token for user: %s", self.username)
-        response = await self.session.post(f"{self.base}/api/accounts/login", json=data)
+        response = await self.session.post(f"{self.base}/api/accounts/login", headers=self.minimal_headers, json=data)
         await raise_for_status(response)
         await self._handle_token_response(response)
 
@@ -195,7 +196,7 @@ class Easee:
         }
         _LOGGER.debug("Refreshing access token")
         try:
-            res = await self.session.post(f"{self.base}/api/accounts/refresh_token", headers=self.headers, json=data)
+            res = await self.session.post(f"{self.base}/api/accounts/refresh_token", headers=self.minimal_headers, json=data)
             await self._handle_token_response(res)
         except AuthorizationFailedException:
             _LOGGER.debug("Could not get new access token from refresh token, getting new one")

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -154,8 +154,6 @@ class Easee:
         """
         if "accessToken" not in self.token:
             await self.connect()
-        accessToken = self.token["accessToken"]
-        self.headers["Authorization"] = f"Bearer {accessToken}"
         _LOGGER.debug(
             "verify_updated_token: %s, %s, %s",
             self.token["expires"],
@@ -164,6 +162,8 @@ class Easee:
         )
         if self.token["expires"] < datetime.now():
             await self._refresh_token()
+        accessToken = self.token["accessToken"]
+        self.headers["Authorization"] = f"Bearer {accessToken}"
 
     async def _handle_token_response(self, res):
         """

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -195,7 +195,7 @@ class Easee:
         }
         _LOGGER.debug("Refreshing access token")
         try:
-            res = await self.session.post(f"{self.base}/api/accounts/refresh_token", json=data)
+            res = await self.session.post(f"{self.base}/api/accounts/refresh_token", headers=self.headers, json=data)
             await self._handle_token_response(res)
         except AuthorizationFailedException:
             _LOGGER.debug("Could not get new access token from refresh token, getting new one")


### PR DESCRIPTION
When a token has expired a new token is requested with the token_refresh API.
However, the request headers were not updated with the new token after the call.
Also, a custom header is added to the login and token_refresh API calls.