### PR TITLE
Upgrading signalrcore to 0.9.5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -42,7 +42,7 @@ regex==2020.6.8
 requests==2.24.0
 requests-toolbelt==0.9.1
 rfc3986==1.4.0
-signalrcore==0.8.8
+signalrcore==0.9.5
 six==1.15.0
 toml==0.10.1
 tqdm==4.47.0
@@ -51,6 +51,5 @@ typed-ast==1.4.1
 urllib3==1.25.9
 wcwidth==0.2.5
 webencodings==0.5.1
-websocket-client==0.54.0
 yarl==1.4.2
 zipp==3.1.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     ],
     packages=["pyeasee"],
     include_package_data=True,
-    install_requires=["aiohttp", "signalrcore==0.8.8", "websocket-client==0.54.0"],
+    install_requires=["aiohttp", "signalrcore==0.9.5"],
     entry_points={"console_scripts": ["pyeasee=pyeasee.__main__:main"]},
 )


### PR DESCRIPTION
(and removed workaround dependancy for websocket-client)

Since there is not anymore any dependance on old versions of webscocket-client in Home Assistant signalrcore can now be updated to latest version.
