### PR TITLE
Changes to better support large installation sites.

### DIFF
--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -363,9 +363,9 @@ class Charger(BaseDict):
 
     async def lockCablePermanently(self, enable: bool):
         """Lock and unlock cable permanently in charger settings"""
-        json = {"lockCablePermanently": enable}
+        json = {"state": enable}
         try:
-            return await self.easee.post(f"/api/chargers/{self.id}/settings", json=json)
+            return await self.easee.post(f"/api/chargers/{self.id}/commands/lock_state", json=json)
         except (ServerFailureException):
             return None
 

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -406,6 +406,16 @@ class Easee:
         except (ServerFailureException):
             return None
 
+    async def get_account_products(self) -> List[Site]:
+        """Get all sites and products that are accessible by the logged in user"""
+        try:
+            records = await (await self.get("/api/accounts/products")).json()
+            _LOGGER.debug("Sites:  %s", records)
+            sites = await asyncio.gather(*[self.get_site(r["id"]) for r in records])
+            return sites
+        except (ServerFailureException):
+            return None
+
     async def get_site_state(self, id: str) -> SiteState:
         """Get site state"""
         try:


### PR DESCRIPTION
Added a new function get_account_products() to retrieve all sites/products that are accessible by the currently logged in user. This is in contrast to the existing get_sites() function which retrieves also products that are not accessible.

Changed the lockCablePermanently() function to use /api/chargers/{id}/commands/lock_state instead because it seems the old method does not work when the user does not have rights to change settings on the charger.