### PR TITLE
Additional changes to get_account_products

### DIFF
--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -411,7 +411,7 @@ class Easee:
         try:
             records = await (await self.get("/api/accounts/products")).json()
             _LOGGER.debug("Sites:  %s", records)
-            sites = await asyncio.gather(*[self.get_site(r["id"]) for r in records])
+            sites = [Site(r, self) for r in records]
             return sites
         except (ServerFailureException):
             return None

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -411,7 +411,12 @@ class Easee:
         try:
             records = await (await self.get("/api/accounts/products")).json()
             _LOGGER.debug("Sites:  %s", records)
-            sites = [Site(r, self) for r in records]
+            sites = []
+            for r in records:
+                site = await self.get_site(r["id"])
+                site["circuits"] = r["circuits"]
+                site["equalizers"] = r["equalizers"]
+                sites.append(site)
             return sites
         except (ServerFailureException):
             return None


### PR DESCRIPTION
When the new function get_account_products() it was not noted that it in turn calls another API to gather more details.
This means that the information from the products API gets lost.
This should solve that by copying that information back in to the site structure.