### PR TITLE
More fine-grained exception handling

### DIFF
--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -13,6 +13,7 @@ import aiohttp
 from .charger import Charger
 from .exceptions import (
     AuthorizationFailedException,
+    BadRequestException,
     ForbiddenServiceException,
     NotFoundException,
     ServerFailureException,
@@ -46,8 +47,8 @@ async def raise_for_status(response):
             data = await response.text()
 
         if 400 == response.status:
-            _LOGGER.error("Bad request service " + f"({response.status}: {data} {response.url})")
-            raise AuthorizationFailedException(data)
+            _LOGGER.debug("Bad request " + f"({response.status}: {data} {response.url})")
+            raise BadRequestException(data)
         elif 401 == response.status:
             _LOGGER.debug("Unautorized " + f"({response.status}: {data} {response.url})")
             raise AuthorizationFailedException(data)
@@ -142,7 +143,7 @@ class Easee:
     async def check_status(self, response):
         try:
             await raise_for_status(response)
-        except AuthorizationFailedException:
+        except (AuthorizationFailedException, BadRequestException):
             _LOGGER.debug("Re authorizing due to 401")
             await self.connect()
             # rethrow it
@@ -204,7 +205,7 @@ class Easee:
                 f"{self.base}/api/accounts/refresh_token", headers=self.minimal_headers, json=data
             )
             await self._handle_token_response(res)
-        except AuthorizationFailedException:
+        except (AuthorizationFailedException, BadRequestException):
             _LOGGER.debug("Could not get new access token from refresh token, getting new one")
             await self.connect()
 

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -13,6 +13,7 @@ import aiohttp
 from .charger import Charger
 from .exceptions import (
     AuthorizationFailedException,
+    ForbiddenServiceException,
     NotFoundException,
     ServerFailureException,
     TooManyRequestsException,
@@ -51,7 +52,8 @@ async def raise_for_status(response):
             _LOGGER.debug("Unautorized " + f"({response.status}: {data} {response.url})")
             raise AuthorizationFailedException(data)
         elif 403 == response.status:
-            _LOGGER.error("Forbidden service " + f"({response.status}: {data} {response.url})")
+            _LOGGER.debug("Forbidden service " + f"({response.status}: {data} {response.url})")
+            raise ForbiddenServiceException(data)
         elif 404 == response.status:
             # Getting this error when getting or deleting charge schedules which doesn't exist (empty)
             _LOGGER.debug("Not found " + f"({response.status}: {data} {response.url})")

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -54,7 +54,7 @@ async def raise_for_status(response):
             raise AuthorizationFailedException(data)
         elif 403 == response.status:
             _LOGGER.debug("Forbidden service" + f"({response.status}: {response.url})")
-            raise ForbiddenServiceException
+            raise ForbiddenServiceException(data)
         elif 404 == response.status:
             # Getting this error when getting or deleting charge schedules which doesn't exist (empty)
             _LOGGER.debug("Not found " + f"({response.status}: {data} {response.url})")
@@ -148,7 +148,7 @@ class Easee:
             await self.connect()
             # rethrow it
             await raise_for_status(response)
-        except ForbiddenServiceException as ex:
+        except ForbiddenServiceException:
             raise
         except Exception as ex:
             _LOGGER.debug("Got other exception from status: %s", type(ex).__name__)

--- a/pyeasee/exceptions.py
+++ b/pyeasee/exceptions.py
@@ -13,5 +13,9 @@ class TooManyRequestsException(Exception):
 class ServerFailureException(Exception):
     pass
 
+
 class ForbiddenServiceException(Exception):
+    pass
+
+class BadRequestException(Exception):
     pass

--- a/pyeasee/exceptions.py
+++ b/pyeasee/exceptions.py
@@ -14,8 +14,23 @@ class ServerFailureException(Exception):
     pass
 
 
-class ForbiddenServiceException(Exception):
-    pass
+class ExceptionWithDict(Exception):
+    def __init__(self, *args):
+        if args:
+            self.message = args[0]
+        else:
+            self.message = None
 
-class BadRequestException(Exception):
-    pass
+    def __str__(self):
+        if self.message:
+            return self.message.get("title", "")
+        else:
+            return f"{type(self).__name__} has been raised"
+
+
+class ForbiddenServiceException(ExceptionWithDict):
+    """Authenticated but access to resource not allowed."""
+
+
+class BadRequestException(ExceptionWithDict):
+    """Bad arguments or operation not allowed in this context."""

--- a/pyeasee/exceptions.py
+++ b/pyeasee/exceptions.py
@@ -12,3 +12,6 @@ class TooManyRequestsException(Exception):
 
 class ServerFailureException(Exception):
     pass
+
+class ForbiddenServiceException(Exception):
+    pass

--- a/pyeasee/site.py
+++ b/pyeasee/site.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 from .utils import BaseDict
 from .charger import Charger, ChargerConfig, ChargerState
-from .exceptions import ServerFailureException
+from .exceptions import ForbiddenServiceException, ServerFailureException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -198,5 +198,5 @@ class Site(BaseDict):
                 await self.easee.get(f"/api/sites/{self.id}/breakdown/{from_date.isoformat()}/{to_date.isoformat()}")
             ).json()
             return costs
-        except (ServerFailureException):
+        except (ServerFailureException, ForbiddenServiceException):
             return None


### PR DESCRIPTION
403 - Forbidden is returned when a user has insufficient privileges to execute the service. 
It happens typically if the user is a `site_user` and attempts to execute a restricted service.

400 - Bad request is used a catch-all for invalid arguments and operation not allowed.