### PR TITLE
Switch to new Easee API domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDEA
+.idea/

--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -194,7 +194,7 @@ class Charger(BaseDict):
         """Gets observation IDs"""
         observation_ids = ",".join(str(s) for s in args)
         try:
-            return await (await self.easee.get(f"/state/{self.id}/observations?ids={observation_ids}", base=1)).json()
+            return await (await self.easee.get(f"/state/{self.id}/observations?ids={observation_ids}")).json()
         except (ServerFailureException):
             return None
 
@@ -439,7 +439,7 @@ class Charger(BaseDict):
     async def get_latest_firmware(self):
         """Get the latest released firmeware version"""
         try:
-            return await (await self.easee.get(f"/firmware/{self.id}/latest", base=1)).json()
+            return await (await self.easee.get(f"/firmware/{self.id}/latest")).json()
         except (ServerFailureException):
             return None
 

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -81,7 +81,7 @@ class Easee:
 
         _LOGGER.info("Easee python library version: %s", __VERSION__)
 
-        self.base = ["https://api.easee.cloud", "https://api.easee.com"]
+        self.base = "https://api.easee.com"
         self.sr_base = "https://streams.easee.com/hubs/chargers"
         self.token = {}
         self.headers = {
@@ -109,33 +109,33 @@ class Easee:
         self._sr_backoff = SR_MIN_BACKOFF
 
     def base_uri(self):
-        return self.base[0]
+        return self.base
 
-    async def post(self, url, base=0, **kwargs):
+    async def post(self, url, **kwargs):
         _LOGGER.debug("POST: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        response = await self.session.post(f"{self.base[base]}{url}", headers=self.headers, **kwargs)
+        response = await self.session.post(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
 
-    async def put(self, url, base=0, **kwargs):
+    async def put(self, url, **kwargs):
         _LOGGER.debug("PUT: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        response = await self.session.put(f"{self.base[base]}{url}", headers=self.headers, **kwargs)
+        response = await self.session.put(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
 
-    async def get(self, url, base=0, **kwargs):
+    async def get(self, url, **kwargs):
         _LOGGER.debug("GET: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        response = await self.session.get(f"{self.base[base]}{url}", headers=self.headers, **kwargs)
+        response = await self.session.get(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
 
-    async def delete(self, url, base=0, **kwargs):
+    async def delete(self, url, **kwargs):
         _LOGGER.debug("DELETE: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        response = await self.session.delete(f"{self.base[base]}{url}", headers=self.headers, **kwargs)
+        response = await self.session.delete(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
 
@@ -188,7 +188,7 @@ class Easee:
         data = {"userName": self.username, "password": self.password}
         _LOGGER.debug("getting token for user: %s", self.username)
         response = await self.session.post(
-            f"{self.base[0]}/api/accounts/login", headers=self.minimal_headers, json=data
+            f"{self.base}/api/accounts/login", headers=self.minimal_headers, json=data
         )
         await raise_for_status(response)
         await self._handle_token_response(response)
@@ -204,7 +204,7 @@ class Easee:
         _LOGGER.debug("Refreshing access token")
         try:
             res = await self.session.post(
-                f"{self.base[0]}/api/accounts/refresh_token", headers=self.minimal_headers, json=data
+                f"{self.base}/api/accounts/refresh_token", headers=self.minimal_headers, json=data
             )
             await self._handle_token_response(res)
         except (AuthorizationFailedException, BadRequestException):

--- a/pyeasee/site.py
+++ b/pyeasee/site.py
@@ -33,7 +33,7 @@ class Equalizer(BaseDict):
         """Gets observation IDs"""
         observation_ids = ",".join(str(s) for s in args)
         try:
-            return await (await self.easee.get(f"/state/{self.id}/observations?ids={observation_ids}", base=1)).json()
+            return await (await self.easee.get(f"/state/{self.id}/observations?ids={observation_ids}")).json()
         except (ServerFailureException):
             return None
 
@@ -66,7 +66,7 @@ class Equalizer(BaseDict):
     async def get_latest_firmware(self):
         """Get the latest released firmeware version"""
         try:
-            return await (await self.easee.get(f"/firmware/{self.id}/latest", base=1)).json()
+            return await (await self.easee.get(f"/firmware/{self.id}/latest")).json()
         except (ServerFailureException):
             return None
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ import pytest
 from aioresponses import aioresponses
 from pyeasee import Charger, Easee
 
-BASE_URL = "https://api.easee.cloud"
+BASE_URL = "https://api.easee.com"
 
 
 def load_json_fixture(filename):


### PR DESCRIPTION
Easee is switching their entire API to the new .com domain

https://developer.easee.cloud/docs

> We are implementing a series of internal modifications to enhance performance and reliability. As part of this process, we have updated the base API URL from api.easee.cloud to api.easee.com.
The api.easee.cloud domain will reach its end of life on September 1st 2023. The api.easee.com domain is already active and we recommend users to update the URL at the earliest convenience.
Please note that this change primarily affects our internal systems, so the only modification required on your end is to update the URL used to connect to our APIs. The endpoints on this page will soon be updated to mirror the modifications.